### PR TITLE
Updated Kafka producer and consumer commands for Windows CMD

### DIFF
--- a/SetUpKafkaDocker.md
+++ b/SetUpKafkaDocker.md
@@ -34,6 +34,13 @@ kafka-console-producer --bootstrap-server kafka1:19092 \
                        --topic test-topic
 ```
 
+-- For Window CMD Operating System
+
+```
+docker exec -it kafka1 kafka-console-producer --bootstrap-server kafka1:19092 --topic test-topic
+```
+
+
 - Consume Messages from the topic.
 
 ```
@@ -41,6 +48,12 @@ docker exec --interactive --tty kafka1  \
 kafka-console-consumer --bootstrap-server kafka1:19092 \
                        --topic test-topic \
                        --from-beginning
+```
+
+-- For Window CMD Operating System
+
+```
+docker exec -it kafka1 kafka-console-consumer --bootstrap-server kafka1:19092 --topic test-topic --from-beginning
 ```
 
 ## Producer and Consume the Messages With Key and Value


### PR DESCRIPTION
The commands provided in the SetUpKafkaDocker file were primarily written for Linux-based operating systems using Linux shell syntax ( \ for multiline commands ). 

When I tried executing the same commands on Windows CMD, they did not work because Windows CMD handles multiline commands differently and does not support Linux-style line continuation.

To improve usability for Windows users, I added equivalent Kafka producer and consumer commands compatible with Windows CMD. These updated commands were tested locally using Docker Desktop and Kafka containers running on Windows.

This change helps developers using Windows environments execute Kafka producer and consumer commands successfully without facing command parsing or executable path issues.